### PR TITLE
add heroku procfile for db migrate on build

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+release: rake db:migrate


### PR DESCRIPTION
Added a heroku procfile to (hopefully) get Heroku to run `rake db:migrate` before it builds acebook. Should let us avoid having to run `heroku run rake db:migrate` in our terminal every time we update the database...